### PR TITLE
Revert "Ignore entitlement machine-config certs that are generated by the PSAP ci-cluster repo we use for testing"

### DIFF
--- a/src/cluster_crypto/yaml_crawl.rs
+++ b/src/cluster_crypto/yaml_crawl.rs
@@ -149,10 +149,6 @@ pub(crate) fn scan_machineconfig(value: &Value) -> Result<Vec<YamlValue>> {
                     for (file_index, file) in files.iter().enumerate() {
                         if let Value::Object(file) = file {
                             if let Some(Value::String(path)) = file.get("path") {
-                                if rules::IGNORE_LIST_MACHINE_CONFIG.contains(path.as_str()) {
-                                    continue;
-                                }
-
                                 if path.ends_with(".pem") || path.ends_with(".crt") {
                                     if let Some(Value::Object(contents)) = file.get("contents") {
                                         if let Some(source) = contents.get("source") {

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -24,14 +24,6 @@ lazy_static! {
         .map(str::to_string)
         .collect();
 
-    pub(crate) static ref IGNORE_LIST_MACHINE_CONFIG: HashSet<String> = vec![
-        "/etc/pki/entitlement/entitlement.pem",
-        "/etc/pki/entitlement/entitlement-key.pem"
-    ]
-        .into_iter()
-        .map(str::to_string)
-        .collect();
-
     // It's okay for some certs to not have a private key, as it's used to sign a few certs and
     // then dropped by its creator. For us it just means we still have to temporarily recreate them
     // in order to regenerate their signees, we just don't have to record them back to the


### PR DESCRIPTION
This rule is unnecessary as we dont'/won't have clusters of any kind for any purpose, which would include these types of certs.
 
This reverts commit 548e9102760195199d41e354765326b181ff0283.