### PR TITLE
Add :Z to the volume arg to podman to deal with selinux

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ sudo chown -R $USER:$USER "$BACKUP_CLUSTER_DIR"/
 rm -rf "$CLUSTER_DIR/" 
 cp -r "$BACKUP_CLUSTER_DIR/" "$CLUSTER_DIR/" 
 ETCD_IMAGE="$(oc adm release extract --from="$RELEASE_IMAGE" --file=image-references | jq '.spec.tags[] | select(.name == "etcd").from.name' -r)"
-sudo podman run --network=host -it --authfile ~/repos/bootstrap-in-place-poc/registry-config.json --entrypoint etcd -v $CLUSTER_DIR/etcd:/store ${ETCD_IMAGE} --name editor --data-dir /store
+sudo podman run --network=host -it --authfile ~/repos/bootstrap-in-place-poc/registry-config.json --entrypoint etcd -v $CLUSTER_DIR/etcd:/store:Z ${ETCD_IMAGE} --name editor --data-dir /store
 ```
 
 #### Run recert


### PR DESCRIPTION
Without this the etcd container failed with:

```
{"level":"fatal","ts":"2023-08-23T18:10:22.892024Z","caller":"etcdmain/etcd.go:435","msg":"failed to list data directory","dir":"/store","error":"open /store: permission denied","stacktrace":"go.etcd.io/etcd/server/v3/etcdmain.identifyDataDirOrDie\n\tgo.etcd.io/etcd/server/v3/etcdmain/etcd.go:435\ngo.etcd.io/etcd/server/v3/etcdmain.startEtcdOrProxyV2\n\tgo.etcd.io/etcd/server/v3/etcdmain/etcd.go:114\ngo.etcd.io/etcd/server/v3/etcdmain.Main\n\tgo.etcd.io/etcd/server/v3/etcdmain/main.go:40\nmain.main\n\tgo.etcd.io/etcd/server/v3/main.go:31\nruntime.main\n\truntime/proc.go:250"}
```