### PR TITLE
MGMT-15538: Add an annotation to edited k8s resources

### DIFF
--- a/src/cluster_crypto/cert_key_pair.rs
+++ b/src/cluster_crypto/cert_key_pair.rs
@@ -12,7 +12,7 @@ use super::{
 };
 use crate::{
     cluster_crypto::{crypto_utils::key_from_file, locations::LocationValueType},
-    file_utils::{get_filesystem_yaml, recreate_yaml_at_location_with_new_pem},
+    file_utils::{add_recert_edited_annotation, get_filesystem_yaml, recreate_yaml_at_location_with_new_pem},
     k8s_etcd::{get_etcd_yaml, InMemoryK8sEtcd},
     rsa_key_pool::RsaKeyPool,
     Customizations,
@@ -308,7 +308,8 @@ impl CertKeyPair {
     }
 
     pub(crate) async fn commit_k8s_cert(&self, etcd_client: &InMemoryK8sEtcd, k8slocation: &K8sLocation) -> Result<()> {
-        let resource = get_etcd_yaml(etcd_client, &k8slocation.resource_location).await?;
+        let mut resource = get_etcd_yaml(etcd_client, &k8slocation.resource_location).await?;
+        add_recert_edited_annotation(&mut resource, &k8slocation.yaml_location)?;
 
         let cert_pem = pem::parse((*self.distributed_cert).borrow().certificate.original.encode_pem())?;
 

--- a/src/cluster_crypto/distributed_private_key.rs
+++ b/src/cluster_crypto/distributed_private_key.rs
@@ -7,7 +7,7 @@ use super::{
     signee::Signee,
 };
 use crate::{
-    file_utils::{get_filesystem_yaml, read_file_to_string, recreate_yaml_at_location_with_new_pem},
+    file_utils::{add_recert_edited_annotation, get_filesystem_yaml, read_file_to_string, recreate_yaml_at_location_with_new_pem},
     k8s_etcd::InMemoryK8sEtcd,
     rsa_key_pool::RsaKeyPool,
     Customizations,
@@ -99,7 +99,8 @@ impl DistributedPrivateKey {
     }
 
     async fn commit_k8s_private_key(&self, etcd_client: &InMemoryK8sEtcd, k8slocation: &K8sLocation) -> Result<()> {
-        let resource = get_etcd_yaml(etcd_client, &k8slocation.resource_location).await?;
+        let mut resource = get_etcd_yaml(etcd_client, &k8slocation.resource_location).await?;
+        add_recert_edited_annotation(&mut resource, &k8slocation.yaml_location)?;
 
         etcd_client
             .put(

--- a/src/cluster_crypto/distributed_public_key.rs
+++ b/src/cluster_crypto/distributed_public_key.rs
@@ -6,7 +6,7 @@ use super::{
     pem_utils,
 };
 use crate::{
-    file_utils::{get_filesystem_yaml, read_file_to_string, recreate_yaml_at_location_with_new_pem},
+    file_utils::{add_recert_edited_annotation, get_filesystem_yaml, read_file_to_string, recreate_yaml_at_location_with_new_pem},
     k8s_etcd::{get_etcd_yaml, InMemoryK8sEtcd},
 };
 use std::fmt::Display;
@@ -64,7 +64,8 @@ impl DistributedPublicKey {
     }
 
     async fn commit_k8s_public_key(&self, etcd_client: &InMemoryK8sEtcd, k8slocation: &K8sLocation) -> Result<()> {
-        let resource = get_etcd_yaml(etcd_client, &k8slocation.resource_location).await?;
+        let mut resource = get_etcd_yaml(etcd_client, &k8slocation.resource_location).await?;
+        add_recert_edited_annotation(&mut resource, &k8slocation.yaml_location)?;
 
         etcd_client
             .put(


### PR DESCRIPTION
The annotation has a string value that is a serialized json object with
its keys being JSON pointers of fields in the annotated resource and
values being a list of PEM bundle indices that were edited (or "N/A" if
the field was not PEM-encoded).

For example:

```
metadata:
  annotations:
    ...
    recert-edited: '{"/spec/config/storage/files/15/contents/source":["1","2","6","5","3","0","4"],"/spec/config/storage/files/21/contents/source":["0"]}'
    ...
```

This annotation is purely informational and is not used programmatically
by recert itself. It's used to help troubleshooters notice this is not a
"natural" cryptographic object, but instead one that was manipulated by
recert.

Resolves https://issues.redhat.com/browse/MGMT-15538
