### PR TITLE
Add `latest` tag to quay builds

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -97,6 +97,10 @@ spec:
       description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       name: build-platforms
       type: array
+    - default: []
+      description: Additional tags to apply to the built container image
+      name: additional-tags
+      type: array
   results:
     - description: ""
       name: IMAGE_URL
@@ -575,6 +579,8 @@ spec:
       params:
         - name: IMAGE
           value: $(tasks.build-image-index.results.IMAGE_URL)
+        - name: ADDITIONAL_TAGS
+          value: $(params.additional-tags[*])
       runAfter:
         - build-image-index
       taskRef:

--- a/.tekton/recert-4-20-pull-request.yaml
+++ b/.tekton/recert-4-20-pull-request.yaml
@@ -62,6 +62,8 @@ spec:
       value: "true"
     - name: skip-sast-coverity
       value: "true"
+    - name: additional-tags
+      value: []
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/recert-4-20-push.yaml
+++ b/.tekton/recert-4-20-push.yaml
@@ -60,6 +60,8 @@ spec:
       value: "true"
     - name: skip-sast-coverity
       value: "true"
+    - name: additional-tags
+      value: ["latest"]
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
             "customType": "regex",
             "datasourceTemplate": "docker",
             "fileMatch": [
-                ".*konflux_build_args\\.conf$"
+                ".*container_build_args\\.conf$"
             ],
             "matchStrings": [
                 "(?<depName>[\\w\\-\\.\\/]+):?(?<currentValue>[\\w\\-\\.]+)?@(?<currentDigest>sha256:[a-f0-9]+)"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying additional tags when building container images in the pipeline. Users can now provide extra image tags via a new parameter.
- **Chores**
  - Updated configuration to align file matching patterns for build argument files in Renovate settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->