### PR TITLE
Fix parsing image from dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ RHEL9_RELEASE ?= $(shell awk '/registry\.redhat\.io\/rhel9.*-els\/rhel:/ {split(
 RHEL9_RELEASE_DASHED := $(subst .,-,$(RHEL9_RELEASE))
 
 # These images are extracted from the Containerfile `FROM` lines
-RHEL9_IMAGE ?= $(shell awk '/^FROM registry\.redhat\.io\/rhel9.*-els\/rhel:/ {split($$2, parts, /[ @]/); print parts[1]}' $(PROJECT_DIR)/.konflux/Dockerfile)
-RHEL9_MINIMAL_IMAGE ?= $(shell awk '/^FROM registry\.redhat\.io\/rhel9.*-els\/rhel-minimal:/ {split($$2, parts, /[ @]/); print parts[1]}' $(PROJECT_DIR)/.konflux/Dockerfile)
+RHEL9_IMAGE ?= $(shell awk '/^FROM registry\.redhat\.io\/rhel9.*-els\/rhel:/ {print $$2}' $(PROJECT_DIR)/.konflux/Dockerfile)
+RHEL9_MINIMAL_IMAGE ?= $(shell awk '/^FROM registry\.redhat\.io\/rhel9.*-els\/rhel-minimal:/ {print $$2}' $(PROJECT_DIR)/.konflux/Dockerfile)
 
 # YAMLLINT_VERSION defines the yamllint version to download from GitHub releases.
 YAMLLINT_VERSION ?= 1.35.1


### PR DESCRIPTION
- We should use the entire image name + tag + digest instead of just parsing the name+tag

AI-attribution: AIA,Entirely human-created,v1.0
For more information on AI attribution statements, see: https://aiattribution.github.io/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features changed.
- Build
  - Simplified the build logic for detecting container base images, improving consistency across environments.
  - Behavior may change regarding whether image tags or digests are included during image resolution.
- Chores
  - Reduced complexity in the build process for easier maintenance.
- Impact
  - No changes to runtime functionality or public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->