### PR TITLE
Fix cert-manager Certificate CR specs and CertificateRequests during IBU

### DIFF
--- a/src/cnsanreplace.rs
+++ b/src/cnsanreplace.rs
@@ -41,6 +41,10 @@ impl CnSanReplace {
 pub(crate) struct CnSanReplaceRules(pub Vec<CnSanReplace>);
 
 impl CnSanReplaceRules {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     pub(crate) fn replace(&self, input: &str) -> String {
         let mut output = input.to_string();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -424,7 +424,7 @@ impl RecertConfig {
             "dry_run and etcd_defrag are mutually exclusive"
         );
         ensure!(
-            !(recert_config.crypto_customizations.ip_change_only && recert_config.crypto_customizations.cn_san_replace_rules.0.is_empty()),
+            !(recert_config.crypto_customizations.ip_change_only && recert_config.crypto_customizations.cn_san_replace_rules.is_empty()),
             "ip-change-only requires at least one cn_san_replace rule"
         );
 

--- a/src/ocp_postprocess.rs
+++ b/src/ocp_postprocess.rs
@@ -4,6 +4,7 @@ use self::{
 };
 use crate::{
     cluster_crypto::locations::K8sResourceLocation,
+    cnsanreplace::CnSanReplaceRules,
     config::{path::ConfigPath, ClusterCustomizations},
     file_utils::{self, read_file_to_string},
     k8s_etcd::{self, get_etcd_json, put_etcd_yaml},
@@ -23,6 +24,7 @@ use std::{
 
 pub(crate) mod additional_trust_bundle;
 mod arguments;
+mod cert_manager_rename;
 pub(crate) mod chrony_config;
 pub(crate) mod cluster_domain_rename;
 pub(crate) mod encryption_config;
@@ -41,6 +43,7 @@ pub mod rename_utils;
 pub(crate) async fn ocp_postprocess(
     in_memory_etcd_client: &Arc<InMemoryK8sEtcd>,
     cluster_customizations: &ClusterCustomizations,
+    cn_san_replace_rules: &CnSanReplaceRules,
 ) -> Result<()> {
     fix_olm_secret_hash_annotation(in_memory_etcd_client)
         .await
@@ -59,6 +62,10 @@ pub(crate) async fn ocp_postprocess(
         .context("syncing webhook authenticators")?;
 
     run_cluster_customizations(cluster_customizations, in_memory_etcd_client).await?;
+
+    cert_manager_rename::fix_cert_manager_certificates(in_memory_etcd_client, cn_san_replace_rules)
+        .await
+        .context("fixing cert-manager certificate specs")?;
 
     // When OpenShift pods/containers start, CVO is still stuck on its last known status and it
     // takes a couple of minutes for it to update its status to the current cluster conditions. When
@@ -1050,3 +1057,4 @@ pub(crate) async fn chrony_config_rename(
 
     Ok(())
 }
+

--- a/src/ocp_postprocess/cert_manager_rename.rs
+++ b/src/ocp_postprocess/cert_manager_rename.rs
@@ -1,0 +1,344 @@
+use crate::{
+    cnsanreplace::CnSanReplaceRules,
+    k8s_etcd::InMemoryK8sEtcd,
+    ocp_postprocess::delete_all,
+};
+use anyhow::{Context, Result};
+use futures_util::future::join_all;
+use std::sync::Arc;
+
+pub(crate) async fn fix_cert_manager_certificates(
+    etcd_client: &Arc<InMemoryK8sEtcd>,
+    cn_san_replace_rules: &CnSanReplaceRules,
+) -> Result<()> {
+    if cn_san_replace_rules.is_empty() {
+        return Ok(());
+    }
+
+    let cert_keys = etcd_client.list_keys("cert-manager.io/certificates/").await?;
+
+    if cert_keys.is_empty() {
+        return Ok(());
+    }
+
+    log::info!("Checking {} cert-manager Certificate CRs for CN/SAN updates", cert_keys.len());
+
+    join_all(cert_keys.into_iter().map(|key| async move {
+        let etcd_result = etcd_client
+            .get(key.clone())
+            .await
+            .with_context(|| format!("getting cert-manager certificate {}", key))?
+            .with_context(|| format!("cert-manager certificate {} disappeared", key))?;
+
+        let mut value: serde_json::Value = serde_json::from_slice(&etcd_result.value)
+            .with_context(|| format!("parsing cert-manager certificate {}", key))?;
+
+        if apply_cn_san_replace_to_certificate(&mut value, cn_san_replace_rules) {
+            etcd_client
+                .put(&key, serde_json::to_string(&value)?.as_bytes().into())
+                .await;
+        }
+
+        Ok(())
+    }))
+    .await
+    .into_iter()
+    .collect::<Result<Vec<_>>>()?;
+
+    // Delete stale CertificateRequest objects. Recert regenerates private keys in TLS
+    // Secrets, but the old CertificateRequests still reference the previous key fingerprint.
+    // cert-manager detects this mismatch and reissues with a fresh key. By deleting the
+    // CertificateRequests, cert-manager will only compare the Certificate CR spec against
+    // the TLS Secret — and since we've already updated both, it won't trigger reissuance.
+    log::info!("Deleting stale cert-manager CertificateRequest objects");
+    delete_all(etcd_client, "cert-manager.io/certificaterequests/").await?;
+
+    Ok(())
+}
+
+/// Apply CN/SAN replacement rules to a cert-manager Certificate CR JSON value.
+/// Updates spec.commonName and spec.dnsNames fields. Returns true if any modifications were made.
+fn apply_cn_san_replace_to_certificate(
+    value: &mut serde_json::Value,
+    cn_san_replace_rules: &CnSanReplaceRules,
+) -> bool {
+    let mut modified = false;
+
+    // Fix spec.commonName
+    if let Some(common_name) = value.pointer_mut("/spec/commonName") {
+        if let Some(cn_str) = common_name.as_str() {
+            let new_cn = cn_san_replace_rules.replace(cn_str);
+            if new_cn != cn_str {
+                log::info!("Updating cert-manager Certificate commonName: {} -> {}", cn_str, new_cn);
+                *common_name = serde_json::Value::String(new_cn);
+                modified = true;
+            }
+        }
+    }
+
+    // Fix spec.dnsNames
+    if let Some(dns_names) = value.pointer_mut("/spec/dnsNames") {
+        if let Some(dns_array) = dns_names.as_array_mut() {
+            for dns_name in dns_array.iter_mut() {
+                if let Some(dns_str) = dns_name.as_str() {
+                    let new_dns = cn_san_replace_rules.replace(dns_str);
+                    if new_dns != dns_str {
+                        log::info!("Updating cert-manager Certificate dnsName: {} -> {}", dns_str, new_dns);
+                        *dns_name = serde_json::Value::String(new_dns);
+                        modified = true;
+                    }
+                }
+            }
+        }
+    }
+
+    modified
+}
+
+#[cfg(test)]
+mod tests {
+    use super::apply_cn_san_replace_to_certificate;
+    use crate::cnsanreplace::{CnSanReplace, CnSanReplaceRules};
+    use serde_json::json;
+
+    fn make_rules(pairs: &[(&str, &str)]) -> CnSanReplaceRules {
+        CnSanReplaceRules(
+            pairs
+                .iter()
+                .map(|(old, new)| CnSanReplace {
+                    old: old.to_string(),
+                    new: new.to_string(),
+                })
+                .collect(),
+        )
+    }
+
+    fn make_certificate(common_name: &str, dns_names: &[&str]) -> serde_json::Value {
+        json!({
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "metadata": {
+                "name": "test-cert",
+                "namespace": "default"
+            },
+            "spec": {
+                "commonName": common_name,
+                "dnsNames": dns_names,
+                "secretName": "test-cert-tls",
+                "issuerRef": {
+                    "name": "test-issuer",
+                    "kind": "Issuer"
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn test_replaces_common_name() {
+        let rules = make_rules(&[("seed.example.com", "target.example.com")]);
+        let mut cert = make_certificate("seed.example.com", &["other.example.com"]);
+
+        let modified = apply_cn_san_replace_to_certificate(&mut cert, &rules);
+
+        assert!(modified);
+        assert_eq!(
+            cert.pointer("/spec/commonName").unwrap().as_str().unwrap(),
+            "target.example.com"
+        );
+        // dnsNames should be unchanged
+        assert_eq!(
+            cert.pointer("/spec/dnsNames/0").unwrap().as_str().unwrap(),
+            "other.example.com"
+        );
+    }
+
+    #[test]
+    fn test_replaces_dns_names() {
+        let rules = make_rules(&[("seed.example.com", "target.example.com")]);
+        let mut cert = make_certificate("other.example.com", &["seed.example.com", "alt.example.com"]);
+
+        let modified = apply_cn_san_replace_to_certificate(&mut cert, &rules);
+
+        assert!(modified);
+        // commonName should be unchanged
+        assert_eq!(
+            cert.pointer("/spec/commonName").unwrap().as_str().unwrap(),
+            "other.example.com"
+        );
+        // First dnsName should be replaced, second unchanged
+        assert_eq!(
+            cert.pointer("/spec/dnsNames/0").unwrap().as_str().unwrap(),
+            "target.example.com"
+        );
+        assert_eq!(
+            cert.pointer("/spec/dnsNames/1").unwrap().as_str().unwrap(),
+            "alt.example.com"
+        );
+    }
+
+    #[test]
+    fn test_replaces_both_common_name_and_dns_names() {
+        let rules = make_rules(&[("seed.example.com", "target.example.com")]);
+        let mut cert = make_certificate("seed.example.com", &["seed.example.com", "other.example.com"]);
+
+        let modified = apply_cn_san_replace_to_certificate(&mut cert, &rules);
+
+        assert!(modified);
+        assert_eq!(
+            cert.pointer("/spec/commonName").unwrap().as_str().unwrap(),
+            "target.example.com"
+        );
+        assert_eq!(
+            cert.pointer("/spec/dnsNames/0").unwrap().as_str().unwrap(),
+            "target.example.com"
+        );
+        assert_eq!(
+            cert.pointer("/spec/dnsNames/1").unwrap().as_str().unwrap(),
+            "other.example.com"
+        );
+    }
+
+    #[test]
+    fn test_no_match_returns_unmodified() {
+        let rules = make_rules(&[("seed.example.com", "target.example.com")]);
+        let mut cert = make_certificate("unrelated.example.com", &["other.example.com"]);
+        let original = cert.clone();
+
+        let modified = apply_cn_san_replace_to_certificate(&mut cert, &rules);
+
+        assert!(!modified);
+        assert_eq!(cert, original);
+    }
+
+    #[test]
+    fn test_exact_match_only() {
+        // CnSanReplaceRules::replace() does exact string matching, not substring
+        let rules = make_rules(&[("seed.example.com", "target.example.com")]);
+        let mut cert = make_certificate(
+            "prefix.seed.example.com",
+            &["sub.seed.example.com", "seed.example.com.suffix"],
+        );
+        let original = cert.clone();
+
+        let modified = apply_cn_san_replace_to_certificate(&mut cert, &rules);
+
+        assert!(!modified);
+        assert_eq!(cert, original);
+    }
+
+    #[test]
+    fn test_multiple_replacement_rules() {
+        let rules = make_rules(&[
+            ("seed.example.com", "target.example.com"),
+            ("api.seed.cluster.local", "api.target.cluster.local"),
+        ]);
+        let mut cert = make_certificate(
+            "seed.example.com",
+            &["api.seed.cluster.local", "other.example.com"],
+        );
+
+        let modified = apply_cn_san_replace_to_certificate(&mut cert, &rules);
+
+        assert!(modified);
+        assert_eq!(
+            cert.pointer("/spec/commonName").unwrap().as_str().unwrap(),
+            "target.example.com"
+        );
+        assert_eq!(
+            cert.pointer("/spec/dnsNames/0").unwrap().as_str().unwrap(),
+            "api.target.cluster.local"
+        );
+        assert_eq!(
+            cert.pointer("/spec/dnsNames/1").unwrap().as_str().unwrap(),
+            "other.example.com"
+        );
+    }
+
+    #[test]
+    fn test_no_common_name_field() {
+        let rules = make_rules(&[("seed.example.com", "target.example.com")]);
+        let mut cert = json!({
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "spec": {
+                "dnsNames": ["seed.example.com"],
+                "secretName": "test-cert-tls"
+            }
+        });
+
+        let modified = apply_cn_san_replace_to_certificate(&mut cert, &rules);
+
+        assert!(modified);
+        assert!(cert.pointer("/spec/commonName").is_none());
+        assert_eq!(
+            cert.pointer("/spec/dnsNames/0").unwrap().as_str().unwrap(),
+            "target.example.com"
+        );
+    }
+
+    #[test]
+    fn test_no_dns_names_field() {
+        let rules = make_rules(&[("seed.example.com", "target.example.com")]);
+        let mut cert = json!({
+            "apiVersion": "cert-manager.io/v1",
+            "kind": "Certificate",
+            "spec": {
+                "commonName": "seed.example.com",
+                "secretName": "test-cert-tls"
+            }
+        });
+
+        let modified = apply_cn_san_replace_to_certificate(&mut cert, &rules);
+
+        assert!(modified);
+        assert_eq!(
+            cert.pointer("/spec/commonName").unwrap().as_str().unwrap(),
+            "target.example.com"
+        );
+        assert!(cert.pointer("/spec/dnsNames").is_none());
+    }
+
+    #[test]
+    fn test_empty_dns_names_array() {
+        let rules = make_rules(&[("seed.example.com", "target.example.com")]);
+        let mut cert = make_certificate("seed.example.com", &[]);
+
+        let modified = apply_cn_san_replace_to_certificate(&mut cert, &rules);
+
+        assert!(modified);
+        assert_eq!(
+            cert.pointer("/spec/commonName").unwrap().as_str().unwrap(),
+            "target.example.com"
+        );
+    }
+
+    #[test]
+    fn test_empty_rules_returns_unmodified() {
+        let rules = make_rules(&[]);
+        let mut cert = make_certificate("seed.example.com", &["seed.example.com"]);
+        let original = cert.clone();
+
+        let modified = apply_cn_san_replace_to_certificate(&mut cert, &rules);
+
+        assert!(!modified);
+        assert_eq!(cert, original);
+    }
+
+    #[test]
+    fn test_all_dns_names_replaced() {
+        let rules = make_rules(&[
+            ("a.seed.com", "a.target.com"),
+            ("b.seed.com", "b.target.com"),
+            ("c.seed.com", "c.target.com"),
+        ]);
+        let mut cert = make_certificate("other.com", &["a.seed.com", "b.seed.com", "c.seed.com"]);
+
+        let modified = apply_cn_san_replace_to_certificate(&mut cert, &rules);
+
+        assert!(modified);
+        let dns_names = cert.pointer("/spec/dnsNames").unwrap().as_array().unwrap();
+        assert_eq!(dns_names[0].as_str().unwrap(), "a.target.com");
+        assert_eq!(dns_names[1].as_str().unwrap(), "b.target.com");
+        assert_eq!(dns_names[2].as_str().unwrap(), "c.target.com");
+    }
+}

--- a/src/recert.rs
+++ b/src/recert.rs
@@ -4,6 +4,7 @@ use crate::{
         scanning::{self, ExternalCerts},
         ClusterCryptoObjects,
     },
+    cnsanreplace::CnSanReplaceRules,
     config::{ClusterCustomizations, CryptoCustomizations, EncryptionCustomizations, RecertConfig},
     encrypt::ResourceTransformers,
     k8s_etcd::InMemoryK8sEtcd,
@@ -45,6 +46,7 @@ pub(crate) async fn run(recert_config: &RecertConfig, cluster_crypto: &mut Clust
         Arc::clone(&in_memory_etcd_client),
         cluster_crypto,
         &recert_config.cluster_customizations,
+        &recert_config.crypto_customizations.cn_san_replace_rules,
         encryption_customizations,
         recert_config.regenerate_server_ssh_keys.as_deref(),
         recert_config.dry_run,
@@ -157,10 +159,12 @@ async fn fill_keys() -> Result<(RunTime, rsa_key_pool::RsaKeyPool)> {
     Ok((RunTime::since_start(start_time), pool))
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn finalize(
     in_memory_etcd_client: Arc<InMemoryK8sEtcd>,
     cluster_crypto: &mut ClusterCryptoObjects,
     cluster_customizations: &ClusterCustomizations,
+    cn_san_replace_rules: &CnSanReplaceRules,
     encryption_customizations: Option<EncryptionCustomizations>,
     regenerate_server_ssh_keys: Option<&Path>,
     dry_run: bool,
@@ -179,7 +183,7 @@ async fn finalize(
 
     let start = std::time::Instant::now();
     if in_memory_etcd_client.etcd_client.is_some() {
-        ocp_postprocess(&in_memory_etcd_client, cluster_customizations)
+        ocp_postprocess(&in_memory_etcd_client, cluster_customizations, cn_san_replace_rules)
             .await
             .context("performing ocp specific post-processing")?;
 


### PR DESCRIPTION
**Jira**: [CNF-21719](https://issues.redhat.com/browse/CNF-21719)

## Problem

During Image-Based Upgrade (IBU), recert regenerates X.509 certificates and updates TLS Secrets with the target cluster's hostname via `cn_san_replace_rules`. However, cert-manager **Certificate CRs** stored in etcd still contain the **seed cluster's** hostname in `spec.commonName` and `spec.dnsNames`. When cert-manager starts on the target cluster, it detects two mismatches that trigger reissuance:

1. **Hostname mismatch** — the Certificate CR spec references the seed hostname while the TLS Secret now contains the target hostname
2. **Key fingerprint mismatch** — stale CertificateRequest objects reference the previous private key fingerprint, which no longer matches the regenerated TLS Secret

This defeats certificate preservation and causes cert-manager to reissue with fresh keys, breaking key continuity.

## Solution

Add a new `cert_manager_rename` postprocessing module that runs during `ocp_postprocess` to:

1. **Update Certificate CR specs** — apply `cn_san_replace_rules` to `spec.commonName` and `spec.dnsNames` fields in cert-manager Certificate CRs stored in etcd, so they match the target cluster's hostname
2. **Delete stale CertificateRequests** — remove CertificateRequest objects from etcd whose key fingerprints reference the old private keys, eliminating the second reissuance trigger

This is the **complementary recert change** referenced in the LCA PR [openshift-kni/lifecycle-agent#5174](https://github.com/openshift-kni/lifecycle-agent/pull/5174), which handles the other side: exporting/restoring TLS Secrets with original key material and passing `use_key` rules to recert. Together, the two changes provide complete cert-manager certificate preservation through IBU.

**Note:** The API server serving certificate (along with ingress and etcd certificates) is already handled natively by recert's existing `cn_san_replace_rules` — it is regenerated with the target cluster's hostname automatically during IBU. This change extends that same capability to cert-manager-managed addon certificates.

Includes 11 unit tests covering hostname replacement logic, exact match semantics, edge cases, and no-op scenarios.


Technical reference: https://gist.github.com/sebrandon1/9c93733b4a0b2ea8dec0784b0c253209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apply configurable CN/SAN replacement rules to cert-manager certificates during post-processing, enabling dynamic certificate renaming.
  * Automatically remove stale certificate request objects to prevent unintended reissuance and keep certificates consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
