### PR TITLE
CNF-22981: add allow-automatic-merge label for rpm-lockfile manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -60,6 +60,14 @@
             ]
         },
         {
+            "addLabels": [
+                "allow-automatic-merge"
+            ],
+            "matchManagers": [
+                "rpm-lockfile"
+            ]
+        },
+        {
             "enabled": false,
             "matchUpdateTypes": [
                 "minor"


### PR DESCRIPTION
## Summary

- Add a `packageRule` to label PRs generated by the `rpm-lockfile` manager with `allow-automatic-merge`
- This enables auto-merge of `rpms.lock.yaml` refresh PRs created by the mintmaker preset (`github>konflux-ci/mintmaker-presets:refresh-rpm-lockfiles`)

## Motivation

PRs like [#1441](https://github.com/rh-ecosystem-edge/recert/pull/1441) (chore(deps): refresh rpm lockfiles) are generated automatically by `red-hat-konflux[bot]` and only update RPM lock file checksums/versions. They should be auto-merged without manual intervention.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced dependency management automation for improved package update handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/recert/pull/1549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->