### PR TITLE
Fix clippy warnings for Rust 1.96

### DIFF
--- a/src/cluster_crypto/scanning.rs
+++ b/src/cluster_crypto/scanning.rs
@@ -275,24 +275,24 @@ pub(crate) async fn scan_filesystem_directory(dir: &Path, external_certs: Extern
         file_utils::globvec(dir, "**/*.pem")?
             .into_iter()
             // Other classic PEM extensions
-            .chain(file_utils::globvec(dir, "**/*.crt")?.into_iter())
-            .chain(file_utils::globvec(dir, "**/*.key")?.into_iter())
-            .chain(file_utils::globvec(dir, "**/*.pub")?.into_iter())
+            .chain(file_utils::globvec(dir, "**/*.crt")?)
+            .chain(file_utils::globvec(dir, "**/*.key")?)
+            .chain(file_utils::globvec(dir, "**/*.pub")?)
             // Also scan for the .mcdorig versions of the above files, which are sometimes created
             // by machine-config-daemon
-            .chain(file_utils::globvec(dir, "**/*.crt.mcdorig")?.into_iter())
-            .chain(file_utils::globvec(dir, "**/*.key.mcdorig")?.into_iter())
-            .chain(file_utils::globvec(dir, "**/*.pub.mcdorig")?.into_iter())
+            .chain(file_utils::globvec(dir, "**/*.crt.mcdorig")?)
+            .chain(file_utils::globvec(dir, "**/*.key.mcdorig")?)
+            .chain(file_utils::globvec(dir, "**/*.pub.mcdorig")?)
             // A file-system copy of machineconfig objects found in /etc/machine-config-daemon/currentconfig
-            .chain(file_utils::globvec(dir, "**/currentconfig")?.into_iter())
+            .chain(file_utils::globvec(dir, "**/currentconfig")?)
             // A file used by MCS
-            .chain(file_utils::globvec(dir, "**/mcs-machine-config-content.json")?.into_iter())
+            .chain(file_utils::globvec(dir, "**/mcs-machine-config-content.json")?)
             // The various names for kubeconfig files
-            .chain(file_utils::globvec(dir, "**/*kubeconfig")?.into_iter())
-            .chain(file_utils::globvec(dir, "**/kubeconfig")?.into_iter())
-            .chain(file_utils::globvec(dir, "**/kubeConfig")?.into_iter())
+            .chain(file_utils::globvec(dir, "**/*kubeconfig")?)
+            .chain(file_utils::globvec(dir, "**/kubeconfig")?)
+            .chain(file_utils::globvec(dir, "**/kubeConfig")?)
             // JWT tokens can be found in files named "token"
-            .chain(file_utils::globvec(dir, "**/token")?.into_iter())
+            .chain(file_utils::globvec(dir, "**/token")?)
             // Skip empty-dir volumes, they contain no meaningful crypto and should just be
             // deleted. But they sometimes contain leftover crypto that trips up recert because it
             // doesn't actually belong to the cluster

--- a/src/k8s_etcd.rs
+++ b/src/k8s_etcd.rs
@@ -242,7 +242,7 @@ impl InMemoryK8sEtcd {
 
         let kubernetes_keys = self.get_keys_with_prefix(etcd_client, "/kubernetes.io", resource_kind).await?;
         let openshift_keys = self.get_keys_with_prefix(etcd_client, "/openshift.io", resource_kind).await?;
-        let mut keys: Vec<_> = kubernetes_keys.into_iter().chain(openshift_keys.into_iter()).collect();
+        let mut keys: Vec<_> = kubernetes_keys.into_iter().chain(openshift_keys).collect();
 
         // Filter out keys that are marked as deleted in our cache.
         let deleted = self.deleted_keys.lock().await;

--- a/src/ocp_postprocess/cluster_domain_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/cluster_domain_rename/etcd_rename.rs
@@ -36,21 +36,18 @@ pub(crate) async fn delete_resources(etcd_client: &Arc<InMemoryK8sEtcd>) -> Resu
             .chain(
                 etcd_client
                     .list_keys("controlplane.operator.openshift.io/podnetworkconnectivitychecks/")
-                    .await?
-                    .into_iter(),
+                    .await?,
             )
             .chain(
                 etcd_client
                     .list_keys("configmaps/openshift-kube-controller-manager/cluster-policy-controller-lock")
-                    .await?
-                    .into_iter(),
+                    .await?,
             )
-            .chain(etcd_client.list_keys("apiserver.openshift.io/apirequestcounts/").await?.into_iter())
+            .chain(etcd_client.list_keys("apiserver.openshift.io/apirequestcounts/").await?)
             .chain(
                 etcd_client
                     .list_keys("operator.openshift.io/ingresscontrollers/openshift-ingress-operator/default")
-                    .await?
-                    .into_iter(),
+                    .await?,
             )
             .map(|key| async move {
                 etcd_client.delete(&key).await.context(format!("deleting {}", key))?;
@@ -1011,8 +1008,7 @@ pub(crate) async fn fix_kcm_kubeconfig(etcd_client: &Arc<InMemoryK8sEtcd>, clust
             .chain(
                 etcd_client
                     .list_keys("configmaps/openshift-kube-scheduler/scheduler-kubeconfig")
-                    .await?
-                    .into_iter(),
+                    .await?,
             )
             .map(|key| async move {
                 let etcd_result = etcd_client

--- a/src/ocp_postprocess/cluster_domain_rename/filesystem_rename.rs
+++ b/src/ocp_postprocess/cluster_domain_rename/filesystem_rename.rs
@@ -12,7 +12,7 @@ pub(crate) async fn fix_filesystem_kcm_pods(generated_infra_id: &str, dir: &Path
     join_all(
         file_utils::globvec(dir, "**/kube-controller-manager-pod.yaml")?
             .into_iter()
-            .chain(file_utils::globvec(dir, "**/kube-controller-manager-pod/pod.yaml")?.into_iter())
+            .chain(file_utils::globvec(dir, "**/kube-controller-manager-pod/pod.yaml")?)
             .map(|file_path| {
                 let kcm_pod_path = file_path.clone();
                 let generated_infra_id = generated_infra_id.to_string();
@@ -229,8 +229,8 @@ pub(crate) async fn fix_filesystem_kubeconfigs(cluster_name: &str, cluster_domai
     join_all(
         file_utils::globvec(dir, "**/*kubeconfig")?
             .into_iter()
-            .chain(file_utils::globvec(dir, "**/kubeconfig")?.into_iter())
-            .chain(file_utils::globvec(dir, "**/kubeConfig")?.into_iter())
+            .chain(file_utils::globvec(dir, "**/kubeconfig")?)
+            .chain(file_utils::globvec(dir, "**/kubeConfig")?)
             // dedup to avoid races
             .collect::<HashSet<_>>()
             .into_iter()

--- a/src/ocp_postprocess/encryption_config/etcd_rename.rs
+++ b/src/ocp_postprocess/encryption_config/etcd_rename.rs
@@ -20,8 +20,7 @@ async fn update_encryption_config(namespace: &str, etcd_client: &Arc<InMemoryK8s
             .chain(
                 etcd_client
                     .list_keys(&format!("secrets/openshift-config-managed/encryption-config-{}", namespace).to_string())
-                    .await?
-                    .into_iter(),
+                    .await?,
             )
             .map(|key| async move {
                 let etcd_result = etcd_client

--- a/src/ocp_postprocess/hostname_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/hostname_rename/etcd_rename.rs
@@ -248,12 +248,7 @@ pub(crate) async fn fix_etcd_pod(etcd_client: &Arc<InMemoryK8sEtcd>, original_ho
             .list_keys("configmaps/openshift-etcd/etcd-pod")
             .await?
             .into_iter()
-            .chain(
-                etcd_client
-                    .list_keys("configmaps/openshift-etcd/restore-etcd-pod")
-                    .await?
-                    .into_iter(),
-            )
+            .chain(etcd_client.list_keys("configmaps/openshift-etcd/restore-etcd-pod").await?)
             .map(|key| async move {
                 let etcd_result = etcd_client
                     .get(key.clone())

--- a/src/ocp_postprocess/ip_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/ip_rename/etcd_rename.rs
@@ -254,12 +254,7 @@ pub(crate) async fn fix_etcd_pod(etcd_client: &Arc<InMemoryK8sEtcd>, original_ip
             .list_keys("configmaps/openshift-etcd/etcd-pod")
             .await?
             .into_iter()
-            .chain(
-                etcd_client
-                    .list_keys("configmaps/openshift-etcd/restore-etcd-pod")
-                    .await?
-                    .into_iter(),
-            )
+            .chain(etcd_client.list_keys("configmaps/openshift-etcd/restore-etcd-pod").await?)
             .map(|key| async move {
                 let etcd_result = etcd_client
                     .get(key.clone())

--- a/src/ocp_postprocess/proxy_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/proxy_rename/etcd_rename.rs
@@ -151,13 +151,13 @@ pub(crate) async fn fix_containers(etcd_client: &InMemoryK8sEtcd, proxy: &Proxy)
             .list_keys("deployments/")
             .await?
             .into_iter()
-            .chain(etcd_client.list_keys("statefulsets/").await?.into_iter())
-            .chain(etcd_client.list_keys("daemonsets/").await?.into_iter())
-            .chain(etcd_client.list_keys("jobs/").await?.into_iter())
-            .chain(etcd_client.list_keys("cronjobs/").await?.into_iter())
-            .chain(etcd_client.list_keys("monitoring.coreos.com/alertmanagers/").await?.into_iter())
-            .chain(etcd_client.list_keys("monitoring.coreos.com/prometheuses/").await?.into_iter())
-            .chain(etcd_client.list_keys("controllerrevisions/").await?.into_iter())
+            .chain(etcd_client.list_keys("statefulsets/").await?)
+            .chain(etcd_client.list_keys("daemonsets/").await?)
+            .chain(etcd_client.list_keys("jobs/").await?)
+            .chain(etcd_client.list_keys("cronjobs/").await?)
+            .chain(etcd_client.list_keys("monitoring.coreos.com/alertmanagers/").await?)
+            .chain(etcd_client.list_keys("monitoring.coreos.com/prometheuses/").await?)
+            .chain(etcd_client.list_keys("controllerrevisions/").await?)
             .map(|key| async move {
                 let etcd_result = etcd_client
                     .get(key.clone())
@@ -345,8 +345,7 @@ pub(crate) async fn fix_configmap_pods(etcd_client: &InMemoryK8sEtcd, proxy: &Pr
             .chain(
                 etcd_client
                     .list_keys("configmaps/openshift-kube-controller-manager/kube-controller-manager-pod")
-                    .await?
-                    .into_iter(),
+                    .await?,
             )
             .map(|key| async move {
                 let etcd_result = etcd_client

--- a/src/ocp_postprocess/rename_utils.rs
+++ b/src/ocp_postprocess/rename_utils.rs
@@ -556,7 +556,7 @@ fn fix_etcd_static_pod_container(container: &mut Value, original_hostname: &str,
             container
                 .pointer("/command")
                 .and_then(|c| c.as_array())
-                .map_or(false, |a| !a.is_empty()),
+                .is_some_and(|a| !a.is_empty()),
             "expected at least one arg in etcd static pod container"
         );
 


### PR DESCRIPTION

Simply ran `cargo clippy --fix`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements and simplified iterator handling across multiple modules for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->