### PR TITLE
feat: support ECDSA private keys in PKCS#8 and SEC1 formats

### DIFF
--- a/src/cluster_crypto/crypto_objects.rs
+++ b/src/cluster_crypto/crypto_objects.rs
@@ -168,7 +168,14 @@ fn process_pem_private_key(pem: &pem::Pem) -> Result<Option<CryptoObject>> {
     let pair = InMemorySigningKeyPair::from_pkcs8_der(pem.contents())?;
 
     Ok(match pair {
-        InMemorySigningKeyPair::Ecdsa(_, _, _) => bail!("private ecdsa pkcs8 unsupported"),
+        InMemorySigningKeyPair::Ecdsa(_, _, pkcs8_der) => {
+            let pubkey_pem = super::crypto_utils::pubkey_pem_from_pkcs8_der(&pkcs8_der).context("extracting EC public key")?;
+
+            let private_part = PrivateKey::Ec(Bytes::from(pkcs8_der));
+            let public_part = PublicKey::Ec(pubkey_pem.into());
+
+            Some((private_part, public_part).into())
+        }
         InMemorySigningKeyPair::Ed25519(_) => bail!("private ed25519 pkcs8 unsupported"),
         InMemorySigningKeyPair::Rsa(_, bytes) => {
             let rsa_private_key = rsa::RsaPrivateKey::from_pkcs1_der(&bytes)?;
@@ -246,4 +253,95 @@ pub(crate) fn process_pem_cert(pem: &pem::Pem, external_certs: &ExternalCerts) -
     }
 
     Ok(Some(CryptoObject::from(hashable_cert)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn generate_ec_pkcs8_pem(curve: &str) -> Vec<u8> {
+        let ecparam = Command::new("openssl")
+            .args(["ecparam", "-name", curve, "-genkey", "-noout"])
+            .output()
+            .expect("failed to run openssl ecparam");
+        assert!(ecparam.status.success(), "ecparam failed");
+
+        let mut child = Command::new("openssl")
+            .args(["pkcs8", "-topk8", "-nocrypt"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn openssl pkcs8");
+
+        child.stdin.take().unwrap().write_all(&ecparam.stdout).unwrap();
+
+        let output = child.wait_with_output().expect("pkcs8 conversion failed");
+        assert!(
+            output.status.success(),
+            "pkcs8 conversion failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output.stdout
+    }
+
+    fn assert_ec_private_key_round_trips(curve: &str) {
+        let pkcs8_pem_bytes = generate_ec_pkcs8_pem(curve);
+        let parsed = pem::parse(&pkcs8_pem_bytes).expect("failed to parse PEM");
+        assert_eq!(parsed.tag(), "PRIVATE KEY");
+
+        let result = process_pem_private_key(&parsed).expect("process_pem_private_key failed");
+        let crypto_obj = result.expect("expected Some(CryptoObject)");
+
+        match crypto_obj {
+            CryptoObject::PrivateKey(private_key, public_key) => {
+                match &private_key {
+                    PrivateKey::Ec(bytes) => {
+                        assert_eq!(bytes.as_ref(), parsed.contents(), "stored bytes should be PKCS#8 DER");
+                    }
+                    _ => panic!("expected PrivateKey::Ec"),
+                }
+                match &public_key {
+                    PublicKey::Ec(pem_bytes) => {
+                        let pub_pem = pem::parse(pem_bytes.as_ref()).expect("public key should be valid PEM");
+                        assert_eq!(pub_pem.tag(), "PUBLIC KEY");
+                    }
+                    _ => panic!("expected PublicKey::Ec"),
+                }
+            }
+            _ => panic!("expected CryptoObject::PrivateKey"),
+        }
+    }
+
+    #[test]
+    fn test_process_pem_private_key_ecdsa_p256_pkcs8() {
+        assert_ec_private_key_round_trips("prime256v1");
+    }
+
+    #[test]
+    fn test_process_pem_private_key_ecdsa_p384_pkcs8() {
+        assert_ec_private_key_round_trips("secp384r1");
+    }
+
+    #[test]
+    fn test_process_pem_private_key_rsa_pkcs8_still_works() {
+        let output = Command::new("openssl")
+            .args(["genpkey", "-algorithm", "RSA", "-pkeyopt", "rsa_keygen_bits:2048"])
+            .output()
+            .expect("failed to generate RSA key");
+        assert!(output.status.success());
+
+        let parsed = pem::parse(&output.stdout).expect("failed to parse PEM");
+        assert_eq!(parsed.tag(), "PRIVATE KEY");
+
+        let result = process_pem_private_key(&parsed).expect("process_pem_private_key failed");
+        let crypto_obj = result.expect("expected Some(CryptoObject)");
+
+        match crypto_obj {
+            CryptoObject::PrivateKey(private_key, _) => {
+                assert!(matches!(private_key, PrivateKey::Rsa(_)), "expected PrivateKey::Rsa");
+            }
+            _ => panic!("expected CryptoObject::PrivateKey"),
+        }
+    }
 }

--- a/src/cluster_crypto/crypto_utils.rs
+++ b/src/cluster_crypto/crypto_utils.rs
@@ -196,13 +196,65 @@ pub(crate) fn key_from_file(path: &Path) -> Result<SigningKey> {
     key_from_pem(&String::from_utf8(data).context("converting private key file to utf8")?)
 }
 
+pub(crate) fn pubkey_pem_from_pkcs8_der(pkcs8_der: &[u8]) -> Result<Vec<u8>> {
+    let mut child = StdCommand::new("openssl")
+        .args(["pkey", "-inform", "DER", "-pubout"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("spawning openssl pkey")?;
+
+    child
+        .stdin
+        .take()
+        .context("failed to take openssl stdin pipe")?
+        .write_all(pkcs8_der)?;
+
+    let output = child.wait_with_output().context("waiting for openssl pkey")?;
+    ensure!(
+        output.status.success(),
+        "openssl pkey -pubout failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    Ok(output.stdout)
+}
+
+fn ec_sec1_to_pkcs8_pem(sec1_pem: &str) -> Result<String> {
+    let mut child = StdCommand::new("openssl")
+        .args(["pkcs8", "-topk8", "-nocrypt"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("spawning openssl pkcs8")?;
+
+    child
+        .stdin
+        .take()
+        .context("failed to take openssl stdin pipe")?
+        .write_all(sec1_pem.as_bytes())?;
+
+    let output = child.wait_with_output().context("waiting for openssl pkcs8")?;
+    ensure!(
+        output.status.success(),
+        "openssl pkcs8 -topk8 failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    String::from_utf8(output.stdout).context("openssl pkcs8 output not valid UTF-8")
+}
+
 pub(crate) fn key_from_pem(pem: &str) -> Result<SigningKey> {
     let parsed_pem = pem::parse(pem.as_bytes()).context("parsing private key file")?;
     let pem_tag = parsed_pem.tag();
 
     match pem_tag {
         "RSA PRIVATE KEY" => rsa_key_from_pkcs1_pem(pem).context("RSA key from PKCS#1"),
-        "EC PRIVATE KEY" => bail!("loading non PKCS#8 EC private keys is not yet supported"),
+        "EC PRIVATE KEY" => ec_sec1_to_pkcs8_pem(pem)
+            .and_then(|pkcs8| key_from_pkcs8_pem(&pkcs8))
+            .context("EC key from SEC1"),
         "PRIVATE KEY" => key_from_pkcs8_pem(pem).context("key from PKCS#8"),
         _ => bail!("unknown private key format"),
     }
@@ -397,5 +449,20 @@ wotPP4a26KThoHHoFw7o6RWG6DPLTYoUIzEe7NmZmk3ZtYTWrut1MTquAv4Juy0A
             fmt.Println(keyID)
         }
         */
+    }
+
+    #[test]
+    fn test_key_from_pem_ec_sec1() {
+        let output = std::process::Command::new("openssl")
+            .args(["ecparam", "-name", "prime256v1", "-genkey", "-noout"])
+            .output()
+            .expect("failed to generate EC key");
+        assert!(output.status.success());
+
+        let sec1_pem = String::from_utf8(output.stdout).unwrap();
+        assert!(sec1_pem.contains("BEGIN EC PRIVATE KEY"));
+
+        let signing_key = super::key_from_pem(&sec1_pem).expect("key_from_pem should accept SEC1 EC keys");
+        assert!(signing_key.pkcs8_pem.starts_with(b"-----BEGIN PRIVATE KEY-----"));
     }
 }


### PR DESCRIPTION
## Summary

Two gaps in ECDSA key format handling:

1. **Scanning path** (`process_pem_private_key`): bailed on ECDSA keys in PKCS#8 format (`"PRIVATE KEY"` tag) even though recert fully supports ECDSA through the SEC1 path. Fixed by extracting PKCS#8 DER bytes and deriving the public key via `openssl pkey -inform DER -pubout` (curve-agnostic).

2. **`--use-key` path** (`key_from_pem`): bailed on SEC1 EC keys (`"EC PRIVATE KEY"` tag) even though the scanning path already converts SEC1 → PKCS#8 via `openssl pkcs8 -topk8 -nocrypt`. Applied the same conversion so `--use-key` rules accept EC keys in either format.

## Context

Fixes [OCPBUGS-94076](https://issues.redhat.com/browse/OCPBUGS-94076). Supersedes [lifecycle-agent#7610](https://github.com/openshift-kni/lifecycle-agent/pull/7610) (closed) — handling the format conversion in recert directly is cleaner than normalizing in LCA.

Related: [recert#1739](https://github.com/rh-ecosystem-edge/recert/issues/1739) (Ed25519 support — separate effort)

## Design decisions

- **`openssl pkey -inform DER -pubout`** for public key extraction in scanning — curve-agnostic, consistent with existing openssl patterns
- **`openssl pkcs8 -topk8 -nocrypt`** for SEC1 → PKCS#8 conversion in `--use-key` — mirrors `process_pem_ec_private_key()`
- **PEM-encoded SPKI bytes in `PublicKey::Ec`** — matches `from_ec_cert_bytes()` for correct `Hash`/`Eq` cert-to-key pairing
- **`Bytes::from(pkcs8_der)`** — zero-copy move of the owned Vec

## Unit tests added

| Test | File | Verifies |
|------|------|----------|
| P-256 ECDSA PKCS#8 | `crypto_objects.rs` | Key accepted, stored as `PrivateKey::Ec` with original DER bytes, public key is valid PEM |
| P-384 ECDSA PKCS#8 | `crypto_objects.rs` | Same for P-384 — confirms curve-agnostic handling |
| RSA PKCS#8 regression | `crypto_objects.rs` | RSA keys still route to `PrivateKey::Rsa` |
| EC SEC1 via `key_from_pem` | `crypto_utils.rs` | SEC1 key accepted, converted to PKCS#8, `SigningKey` created successfully |

## E2E validation

Full 4.22.0 → 4.22.3 IBU on cnfdf22 (vcl01-hv9) with cert-manager ECDSA and RSA certificates:

| Secret | Key Algorithm | Survived IBU? |
|--------|--------------|---------------|
| test-ecdsa-p256-tls | ECDSA P-256 (SEC1 format) | Yes |
| test-ecdsa-p384-tls | ECDSA P-384 (SEC1 format) | Yes |
| test-rsa-2048-tls | RSA 2048 (PKCS#1 format) | Yes |

All cert-manager TLS secrets preserved with correct CNs after the upgrade. [Full validation writeup](https://gist.github.com/sebrandon1/e99c965ba099d2d7ebf1bf53331b5c5a).