### PR TITLE
Fix Dockerfile build failure by pinning cargo-chef transitive deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The rust version is pinned to prevent unexpected breakages due to rust changes.
 FROM rust:1.87 AS chef
-RUN cargo install cargo-chef --version 0.1.75
+RUN cargo install cargo-chef --version 0.1.75 --locked
 WORKDIR /app
 
 FROM chef AS planner

--- a/src/ocp_postprocess/cluster_domain_rename/etcd_rename.rs
+++ b/src/ocp_postprocess/cluster_domain_rename/etcd_rename.rs
@@ -181,7 +181,6 @@ pub(crate) async fn fix_ingresscontroller_status_domain(etcd_client: &Arc<InMemo
     Ok(())
 }
 
-
 pub(crate) async fn fix_oauth_client(
     etcd_client: &Arc<InMemoryK8sEtcd>,
     cluster_domain: &str,


### PR DESCRIPTION
This is not an issue with recert, but with a build tool called `cargo-chef` which we use to improve performance of Docker builds. The command to install it (through building from source) is:

    cargo install cargo-chef --version 0.1.75

`cargo install cargo-chef --version 0.1.75` resolves cargo-chef's own transitive dependencies at install time. The `ignore` crate recently published v0.4.30, which uses let-chain expressions (`let` in `&&` position), a feature not stabilized in Rust 1.87. This causes the build to fail:

    error[E0658]: `let` expressions in this position are unstable
       --> ignore-0.4.30/src/incremental.rs:274:16
        |
    274 |             && let Some(max_filesize) = self.options.max_filesize
        |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        |
        = note: see issue #53667 for more information

    error[E0658]: `let` expressions in this position are unstable
       --> ignore-0.4.30/src/incremental.rs:337:42
        |
    337 |         if has_normal_final_component && let Some(parent) = relative.parent() {
        |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    error: could not compile `ignore` (lib) due to 2 previous errors
    error: failed to compile `cargo-chef v0.1.75`

Adding `--locked` makes `cargo install` use the Cargo.lock shipped with cargo-chef v0.1.75, which pins `ignore` to a version compatible with Rust 1.87.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build reproducibility by enforcing the dependency lockfile when installing the build tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->