### PR TITLE
[release-4.21] Fix Dockerfile build failure by pinning cargo-chef transitive deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The rust version is pinned to prevent unexpected breakages due to rust changes.
 FROM rust:1.87 AS chef
-RUN cargo install cargo-chef --version 0.1.75
+RUN cargo install cargo-chef --version 0.1.75 --locked
 WORKDIR /app
 
 FROM chef AS planner


### PR DESCRIPTION
Backport of aea48b0108488380631f092c793699e02ef34556
