### PR TITLE
fix: skip non-UTF-8 byte array values during scanning

### DIFF
--- a/src/cluster_crypto/json_crawl.rs
+++ b/src/cluster_crypto/json_crawl.rs
@@ -276,7 +276,11 @@ fn process_byte_array_value(value: &Value) -> Result<Option<String>> {
                     bail!("non-number in array");
                 }
             }
-            Some(String::from_utf8(bytes).context("non-utf8 decoded byte array value")?)
+            if let Ok(decoded) = String::from_utf8(bytes) {
+                Some(decoded)
+            } else {
+                None
+            }
         }
         _ => None,
     })


### PR DESCRIPTION
## Summary

`process_byte_array_value()` in `json_crawl.rs` hard-fails on non-UTF-8 binary data (e.g. DER-encoded keys stored as byte arrays in etcd secrets like `keycloak/keycloak-database-client-cert`). DER files are raw binary and will never contain PEM text, so there is nothing to scan.

```
Error: scanning and recertification
    Caused by:
        0: scanning etcd/filesystem
        1: etcd resources
        2: decoding yaml of key "/kubernetes.io/secrets/keycloak/keycloak-database-client-cert"
        3: decoding value at JsonLocation { json_pointer: "/data/key.der", value: YetUnknown, encoding: ByteArray }
        4: decoding byte array value
        5: non-utf8 decoded byte array value
```

The same situation is already handled gracefully by `process_data_url_value()`, which returns `None` for non-UTF-8 data with the comment "We don't search for crypto objects inside binaries".

## Fix

Return `None` for non-UTF-8 byte arrays instead of erroring — matching the existing `process_data_url_value()` pattern.

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo test` — all 35 tests pass
- [x] `cargo fmt --check` — formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid UTF-8 data in byte array JSON values.
  * Undecodable values are now skipped instead of causing the decoding process to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->