### PR TITLE
Switch runtime base image to ubi9-minimal-pqc for PQC compliance

### DIFF
--- a/.konflux/Dockerfile
+++ b/.konflux/Dockerfile
@@ -1,6 +1,6 @@
 # See README.Konflux.md before editing this Dockerfile
 ARG BUILDER_IMAGE=registry.access.redhat.com/ubi9/ubi:latest
-ARG RUNTIME_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest
+ARG RUNTIME_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest
 
 # build stage
 FROM ${BUILDER_IMAGE} AS builder-image

--- a/.konflux/container_build_args.conf
+++ b/.konflux/container_build_args.conf
@@ -11,5 +11,5 @@ BUILDER_IMAGE=registry.access.redhat.com/ubi9/ubi:latest@sha256:e79f79172a677977
 # The runtime image is used to run the binaries
 # This should match the dummy file Dockerfile.mintmaker in the lock-runtime directory
 # Mintmaker should keep these in sync automatically when it performs updates
-RUNTIME_IMAGE=registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:dd334afa72444fa46238fcf9e6bd399245adf746378735348cf84b9dfdca38f1
+RUNTIME_IMAGE=registry.redhat.io/ubi9/ubi-minimal-pqc:latest@sha256:e7f7720259142a68a8087fb4df9d21a91189863aa083e9b27c2c2801878ef5c4
 #

--- a/.konflux/lock-runtime/Dockerfile.mintmaker
+++ b/.konflux/lock-runtime/Dockerfile.mintmaker
@@ -1,5 +1,5 @@
 # Due to a limitation in Mintmaker, we need to create a dummy Dockerfile that does not use ARGs
 # This should match the RUNTIME_IMAGE in container_build_args.conf
 # Mintmaker should keep these in sync automatically when it performs updates
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:dd334afa72444fa46238fcf9e6bd399245adf746378735348cf84b9dfdca38f1
+FROM registry.redhat.io/ubi9/ubi-minimal-pqc:latest@sha256:e7f7720259142a68a8087fb4df9d21a91189863aa083e9b27c2c2801878ef5c4
 #

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ konflux-update-rpm-lock-runtime: sync-git-submodules ## Update the rpm lock file
 	@echo "Updating rpm lock file for the runtime..."
 	$(MAKE) -C $(PROJECT_DIR)/telco5g-konflux/scripts/rpm-lock generate-rhel9-locks \
 		LOCK_SCRIPT_TARGET_DIR=$(PROJECT_DIR)/.konflux/lock-runtime/tmp/ \
-		RHEL9_EXECUTION_IMAGE=$$(awk -F'=' '/^RUNTIME_IMAGE=/ {print $$2}' $(PROJECT_DIR)/.konflux/container_build_args.conf | sed 's|ubi-minimal|ubi|g' | sed 's|@.*||') \
+		RHEL9_EXECUTION_IMAGE=$$(awk -F'=' '/^RUNTIME_IMAGE=/ {print $$2}' $(PROJECT_DIR)/.konflux/container_build_args.conf | sed 's|ubi-minimal[^:]*|ubi|' | sed 's|@.*||') \
 		RHEL9_IMAGE_TO_LOCK=$$(awk -F'=' '/^RUNTIME_IMAGE=/ {print $$2}' $(PROJECT_DIR)/.konflux/container_build_args.conf)
 	@echo "Update rpms.lock.yaml with new contents..."
 	cp $(PROJECT_DIR)/.konflux/lock-runtime/tmp/rpms.lock.yaml $(PROJECT_DIR)/.konflux/lock-runtime/rpms.lock.yaml


### PR DESCRIPTION
## Summary

Switch the runtime base image from `ubi9/ubi-minimal` to `ubi9/ubi-minimal-pqc` to enable the `DEFAULT:PQ` crypto-policy in the container, as required by [OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113) for platform-wide PQC consistency.

## Changes

- **`.konflux/Dockerfile`**: Updated `RUNTIME_IMAGE` ARG default from `ubi9/ubi-minimal:latest` to `ubi9/ubi-minimal-pqc:latest`
- **`.konflux/container_build_args.conf`**: Updated `RUNTIME_IMAGE` to point to `ubi9/ubi-minimal-pqc:latest` with pinned digest
- **`.konflux/lock-runtime/Dockerfile.mintmaker`**: Updated `FROM` to match the new runtime image with pinned digest

## Context

Per [OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113), all OpenShift components must switch to the new PQC base images for platform consistency. Recert uses system OpenSSL for certificate signing and key generation via Rust crypto crates, so the `DEFAULT:PQ` policy applies to its OpenSSL-delegated operations.

## Test plan

- [ ] Verify no regressions in certificate regeneration in standard mode (non-FIPS)
- [ ] Verify no regressions in FIPS mode (PQC modules auto-disabled by FIPS provider)
- [ ] RPM lockfile will be regenerated automatically by Mintmaker after merge

## References

- Jira: [CNF-26437](https://redhat.atlassian.net/browse/CNF-26437)
- Parent initiative: [OCPSTRAT-3113](https://redhat.atlassian.net/browse/OCPSTRAT-3113)
- Similar PR for NROP: [CNF-26427](https://redhat.atlassian.net/browse/CNF-26427)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runtime environment to use the UBI minimal post-quantum cryptography (PQC) image.
  * Pinned the runtime and build images to updated image digests for consistent deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->